### PR TITLE
Add accessors for predicate & fetch request, also add an FRC builder

### DIFF
--- a/Kuery.xcodeproj/project.pbxproj
+++ b/Kuery.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 				147DB3DC1EF116230071DAC5 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		147DB3DC1EF116230071DAC5 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
In our projects we almost always use NSFetchedResultsController, where we need to provide the fetch request. In some other cases, we just need to build a predicate.

Currently there's no way to get the `Query`'s fetch request, it's private, and for a good reason. This PR adds getters for:
- The predicate: no issues, it's immutable
- The fetch request: it creates a copy to avoid external mutation
- Generate a controller: needs some extra parameters, and a check to see if there's at least 1 sort descriptor